### PR TITLE
Correction Vulnerabilité commons-collections-3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 	<dependency>
 		<groupId>commons-collections</groupId>
 		<artifactId>commons-collections</artifactId>
-		<version>3.2.1</version>
+		<version>3.2.2</version>
 	</dependency>
 	
 	<dependency>


### PR DESCRIPTION
Forcer la version 3.2.2 corrigeant la faille de sécurité.
cf https://commons.apache.org/proper/commons-collections/security-reports.html
