### PR TITLE
ci(travis): setup travis continuous integration for open source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
Travis CI provides free continuous integration to open source projects.
Continuous integration makes it easier for contributors to see if changes being proposed would work, and easier for maintainers to ensure that changes work across multiple machines/platforms.

https://docs.travis-ci.com/user/getting-started